### PR TITLE
feat: add support for MCP Protocol 2025-06-18 with output schemas 

### DIFF
--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/models"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/parser"
 	"github.com/stretchr/testify/assert"
@@ -236,9 +238,86 @@ func TestCreateOutputSchemaArray(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "object", items["type"])
 
+	// Verify nested properties in array items
+	itemsProps, ok := items["properties"].(map[string]any)
+	assert.True(t, ok)
+	assert.Contains(t, itemsProps, "id")
+	assert.Contains(t, itemsProps, "name")
+	assert.Contains(t, itemsProps, "email")
+
 	// Verify required fields
 	required, ok := outputSchema["required"].([]string)
 	assert.True(t, ok)
 	assert.Contains(t, required, "users")
 	assert.Contains(t, required, "total")
+}
+
+func TestConvertPropertiesRecursive(t *testing.T) {
+	// Create a new parser
+	p := parser.NewParser()
+
+	// Parse the test file
+	err := p.ParseFile("../../test/output-schema-test.json")
+	assert.NoError(t, err)
+
+	// Create a converter
+	c := NewConverter(p, models.ConvertOptions{
+		ServerName: "test-server",
+	})
+
+	// Get the document and user operation to test nested properties
+	doc := p.GetDocument()
+	userOperation := doc.Paths.Find("/user/{id}").Get
+
+	// Get the response schema
+	var successResponse *openapi3.Response
+	if userOperation.Responses != nil {
+		for code, responseRef := range userOperation.Responses {
+			if strings.HasPrefix(code, "2") && responseRef != nil && responseRef.Value != nil {
+				successResponse = responseRef.Value
+				break
+			}
+		}
+	}
+
+	assert.NotNil(t, successResponse)
+	assert.NotNil(t, successResponse.Content)
+
+	// Get the schema from the first content type
+	var schema *openapi3.Schema
+	for _, mediaType := range successResponse.Content {
+		if mediaType.Schema != nil && mediaType.Schema.Value != nil {
+			schema = mediaType.Schema.Value
+			break
+		}
+	}
+
+	assert.NotNil(t, schema)
+
+	// Test the convertProperties function directly
+	if schema.Type == "object" && len(schema.Properties) > 0 {
+		properties := c.convertProperties(schema.Properties, schema.Required)
+
+		// Verify top-level properties
+		assert.Contains(t, properties, "id")
+		assert.Contains(t, properties, "name")
+		assert.Contains(t, properties, "email")
+		assert.Contains(t, properties, "profile")
+
+		// Verify nested properties in profile
+		profileProp, ok := properties["profile"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "object", profileProp["type"])
+
+		profileProps, ok := profileProp["properties"].(map[string]any)
+		assert.True(t, ok)
+		assert.Contains(t, profileProps, "bio")
+		assert.Contains(t, profileProps, "website")
+
+		// Verify bio property in nested profile
+		bioProp, ok := profileProps["bio"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "string", bioProp["type"])
+		assert.Equal(t, "User biography", bioProp["description"])
+	}
 }

--- a/pkg/models/mcp_config.go
+++ b/pkg/models/mcp_config.go
@@ -46,6 +46,7 @@ type Tool struct {
 	ResponseTemplate      ResponseTemplate         `yaml:"responseTemplate"`
 	ErrorResponseTemplate *string                  `yaml:"errorResponseTemplate,omitempty"`
 	Security              *ToolSecurityRequirement `yaml:"security,omitempty"`
+	OutputSchema          map[string]any           `yaml:"outputSchema,omitempty"` // NEW: Output schema for MCP 2025-06-18
 }
 
 // Arg represents an MCP tool argument
@@ -105,6 +106,7 @@ type ToolTemplate struct {
 	RequestTemplate  *RequestTemplate         `yaml:"requestTemplate,omitempty"`
 	ResponseTemplate *ResponseTemplate        `yaml:"responseTemplate,omitempty"`
 	Security         *ToolSecurityRequirement `yaml:"security,omitempty"`
+	OutputSchema     map[string]any           `yaml:"outputSchema,omitempty"` // NEW: Output schema template
 }
 
 // MCPConfigTemplate represents a template for patching the generated config

--- a/test/array-complex-items.json
+++ b/test/array-complex-items.json
@@ -1,0 +1,116 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Array Complex Items Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users with complex array items",
+        "description": "Retrieve users with detailed profiles in array items",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Filter by tags (array of objects)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Tag name"
+                  },
+                  "color": {
+                    "type": "string",
+                    "description": "Tag color",
+                    "enum": ["red", "blue", "green"]
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "description": "List of users",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "User ID"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "User name"
+                          },
+                          "profile": {
+                            "type": "object",
+                            "description": "User profile",
+                            "properties": {
+                              "bio": {
+                                "type": "string",
+                                "description": "User biography"
+                              },
+                              "skills": {
+                                "type": "array",
+                                "description": "User skills",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Skill name"
+                                    },
+                                    "level": {
+                                      "type": "string",
+                                      "description": "Skill level",
+                                      "enum": [
+                                        "beginner",
+                                        "intermediate",
+                                        "expert"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["name"]
+                                }
+                              }
+                            },
+                            "required": ["bio"]
+                          }
+                        },
+                        "required": ["id", "name"]
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total number of users"
+                    }
+                  },
+                  "required": ["users", "total"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/deep-nested-request-body.json
+++ b/test/deep-nested-request-body.json
@@ -1,0 +1,140 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Deep Nested Request Body Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1"
+    }
+  ],
+  "paths": {
+    "/companies": {
+      "post": {
+        "summary": "Create company with nested data",
+        "description": "Create a new company with deep nested structure",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Company name"
+                  },
+                  "departments": {
+                    "type": "array",
+                    "description": "Company departments",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Department name"
+                        },
+                        "manager": {
+                          "type": "object",
+                          "description": "Department manager",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "Manager name"
+                            },
+                            "contact": {
+                              "type": "object",
+                              "description": "Manager contact info",
+                              "properties": {
+                                "email": {
+                                  "type": "string",
+                                  "description": "Manager email"
+                                },
+                                "phone": {
+                                  "type": "string",
+                                  "description": "Manager phone"
+                                }
+                              },
+                              "required": ["email"]
+                            }
+                          },
+                          "required": ["name", "contact"]
+                        },
+                        "employees": {
+                          "type": "array",
+                          "description": "Department employees",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "Employee ID"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Employee name"
+                              },
+                              "skills": {
+                                "type": "array",
+                                "description": "Employee skills",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Skill name"
+                                    },
+                                    "level": {
+                                      "type": "string",
+                                      "description": "Skill level",
+                                      "enum": [
+                                        "beginner",
+                                        "intermediate",
+                                        "expert"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["name"]
+                                }
+                              }
+                            },
+                            "required": ["id", "name"]
+                          }
+                        }
+                      },
+                      "required": ["name", "manager"]
+                    }
+                  }
+                },
+                "required": ["name", "departments"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Company created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "Company ID"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/deep-nested-test.json
+++ b/test/deep-nested-test.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Deep Nested Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1"
+    }
+  ],
+  "paths": {
+    "/deep": {
+      "get": {
+        "summary": "Get deep nested data",
+        "description": "Retrieve data with multiple levels of nesting",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "company": {
+                      "type": "object",
+                      "description": "Company information",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Company name"
+                        },
+                        "departments": {
+                          "type": "array",
+                          "description": "Company departments",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Department name"
+                              },
+                              "manager": {
+                                "type": "object",
+                                "description": "Department manager",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Manager name"
+                                  },
+                                  "contact": {
+                                    "type": "object",
+                                    "description": "Manager contact info",
+                                    "properties": {
+                                      "email": {
+                                        "type": "string",
+                                        "description": "Manager email"
+                                      },
+                                      "phone": {
+                                        "type": "string",
+                                        "description": "Manager phone"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "employees": {
+                                "type": "array",
+                                "description": "Department employees",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "integer",
+                                      "description": "Employee ID"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Employee name"
+                                    },
+                                    "skills": {
+                                      "type": "array",
+                                      "description": "Employee skills",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Skill name"
+                                          },
+                                          "level": {
+                                            "type": "string",
+                                            "description": "Skill level",
+                                            "enum": [
+                                              "beginner",
+                                              "intermediate",
+                                              "expert"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": ["company"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/expected-allof-params-mcp.yaml
+++ b/test/expected-allof-params-mcp.yaml
@@ -53,3 +53,16 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: OK
+      properties:
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        phone:
+          type: string
+      type: object

--- a/test/expected-cookie-params-mcp.yaml
+++ b/test/expected-cookie-params-mcp.yaml
@@ -35,6 +35,20 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: User preferences
+      properties:
+        language:
+          description: Language preference
+          type: string
+        notifications:
+          description: Notification preference
+          type: boolean
+        theme:
+          description: UI theme preference
+          type: string
+      type: object
   - name: getSession
     description: Get session information
     args:
@@ -65,3 +79,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: Session information
+      properties:
+        created:
+          description: Session creation time
+          type: string
+        expires:
+          description: Session expiration time
+          type: string
+        userId:
+          description: User ID associated with the session
+          type: string
+      type: object

--- a/test/expected-header-params-mcp.yaml
+++ b/test/expected-header-params-mcp.yaml
@@ -34,6 +34,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: Authentication successful
+      properties:
+        authenticated:
+          description: Authentication status
+          type: boolean
+        expires:
+          description: Token expiration time
+          type: string
+      type: object
   - name: getSecureResource
     description: Get secure resource
     args:
@@ -66,3 +77,11 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: Secure resource retrieved successfully
+      properties:
+        data:
+          description: Secure data
+          type: string
+      type: object

--- a/test/expected-output-schema-test-mcp.yaml
+++ b/test/expected-output-schema-test-mcp.yaml
@@ -1,0 +1,107 @@
+server:
+  name: output-schema-api
+tools:
+  - name: get_user_id
+    description: Get user by ID - Retrieve a single user by ID
+    args:
+      - name: id
+        description: User ID
+        type: integer
+        required: true
+        position: path
+    requestTemplate:
+      url: https://api.example.com/v1/user/{id}
+      method: GET
+    responseTemplate:
+      prependBody: |+
+        # API Response Information
+
+        Below is the response from an API call. To help you understand the data, I've provided:
+
+        1. A detailed description of all fields in the response structure
+        2. The complete API response
+
+        ## Response Structure
+
+        > Content-Type: application/json
+
+        - **email**: User email (Type: string)
+        - **id**: User ID (Type: integer)
+        - **name**: User name (Type: string)
+        - **profile**: User profile information (Type: object)
+          - **profile.bio**: User biography (Type: string)
+          - **profile.website**: User website (Type: string)
+
+        ## Original Response
+
+    outputSchema:
+      contentType: application/json
+      description: Successful response
+      properties:
+        email:
+          description: User email
+          type: string
+        id:
+          description: User ID
+          type: integer
+        name:
+          description: User name
+          type: string
+        profile:
+          description: User profile information
+          properties:
+            bio:
+              description: User biography
+              type: string
+            website:
+              description: User website
+              type: string
+          type: object
+      required:
+        - id
+        - name
+        - email
+      type: object
+  - name: get_users
+    description: Get users list - Retrieve a list of users
+    args: []
+    requestTemplate:
+      url: https://api.example.com/v1/users
+      method: GET
+    responseTemplate:
+      prependBody: |+
+        # API Response Information
+
+        Below is the response from an API call. To help you understand the data, I've provided:
+
+        1. A detailed description of all fields in the response structure
+        2. The complete API response
+
+        ## Response Structure
+
+        > Content-Type: application/json
+
+        - **total**: Total number of users (Type: integer)
+        - **users**: List of users (Type: array)
+          - **users[].email**: User email (Type: string)
+          - **users[].id**: User ID (Type: integer)
+          - **users[].name**: User name (Type: string)
+
+        ## Original Response
+
+    outputSchema:
+      contentType: application/json
+      description: Successful response
+      properties:
+        total:
+          description: Total number of users
+          type: integer
+        users:
+          description: List of users
+          items:
+            type: object
+          type: array
+      required:
+        - users
+        - total
+      type: object

--- a/test/expected-output-schema-test-mcp.yaml
+++ b/test/expected-output-schema-test-mcp.yaml
@@ -99,6 +99,19 @@ tools:
         users:
           description: List of users
           items:
+            properties:
+              email:
+                description: User email
+                type: string
+              id:
+                description: User ID
+                type: integer
+              name:
+                description: User name
+                type: string
+            required:
+              - id
+              - name
             type: object
           type: array
       required:

--- a/test/expected-path-params-mcp.yaml
+++ b/test/expected-path-params-mcp.yaml
@@ -31,6 +31,20 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: User information
+      properties:
+        email:
+          description: User email
+          type: string
+        id:
+          description: User ID
+          type: string
+        name:
+          description: User name
+          type: string
+      type: object
   - name: updateUser
     description: Update user
     args:

--- a/test/expected-petstore-mcp.yaml
+++ b/test/expected-petstore-mcp.yaml
@@ -51,6 +51,18 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: A paged array of pets
+      properties:
+        nextPage:
+          description: URL to get the next page of pets
+          type: string
+        pets:
+          items:
+            type: object
+          type: array
+      type: object
   - name: showPetById
     description: Info for a specific pet
     args:
@@ -81,3 +93,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: Expected response to a valid request
+      properties:
+        id:
+          description: Unique identifier for the pet
+          type: integer
+        name:
+          description: Name of the pet
+          type: string
+        tag:
+          description: Tag of the pet
+          type: string
+      type: object

--- a/test/expected-petstore-mcp.yaml
+++ b/test/expected-petstore-mcp.yaml
@@ -60,6 +60,16 @@ tools:
           type: string
         pets:
           items:
+            properties:
+              id:
+                description: Unique identifier for the pet
+                type: integer
+              name:
+                description: Name of the pet
+                type: string
+              tag:
+                description: Tag of the pet
+                type: string
             type: object
           type: array
       type: object

--- a/test/expected-petstore-template-mcp.yaml
+++ b/test/expected-petstore-template-mcp.yaml
@@ -71,6 +71,16 @@ tools:
           type: string
         pets:
           items:
+            properties:
+              id:
+                description: Unique identifier for the pet
+                type: integer
+              name:
+                description: Name of the pet
+                type: string
+              tag:
+                description: Tag of the pet
+                type: string
             type: object
           type: array
       type: object

--- a/test/expected-petstore-template-mcp.yaml
+++ b/test/expected-petstore-template-mcp.yaml
@@ -62,6 +62,18 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: A paged array of pets
+      properties:
+        nextPage:
+          description: URL to get the next page of pets
+          type: string
+        pets:
+          items:
+            type: object
+          type: array
+      type: object
   - name: showPetById
     description: Info for a specific pet
     args:
@@ -97,3 +109,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: Expected response to a valid request
+      properties:
+        id:
+          description: Unique identifier for the pet
+          type: integer
+        name:
+          description: Name of the pet
+          type: string
+        tag:
+          description: Tag of the pet
+          type: string
+      type: object

--- a/test/expected-request-body-types-mcp.yaml
+++ b/test/expected-request-body-types-mcp.yaml
@@ -85,3 +85,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      description: File uploaded successfully
+      properties:
+        fileId:
+          description: ID of the uploaded file
+          type: string
+        fileName:
+          description: Name of the uploaded file
+          type: string
+        fileSize:
+          description: Size of the uploaded file in bytes
+          type: integer
+      type: object

--- a/test/expected-tools-args-array-of-object-mcp.yaml
+++ b/test/expected-tools-args-array-of-object-mcp.yaml
@@ -43,3 +43,17 @@ tools:
 
         ## Original Response
 
+    outputSchema:
+      contentType: application/json
+      properties:
+        code:
+          description: 状态值
+          type: number
+        data:
+          description: 数据
+          properties:
+            pages:
+              description: 识别pages
+              type: array
+          type: object
+      type: object

--- a/test/expected-tools-args-array-of-object-mcp.yaml
+++ b/test/expected-tools-args-array-of-object-mcp.yaml
@@ -12,9 +12,9 @@ tools:
           description: image
           properties:
             image:
-              type: string
-              description: 图片base64
               default: ""
+              description: 图片base64
+              type: string
           type: object
         position: body
     requestTemplate:

--- a/test/expected-tools-args-array-of-object-mcp.yaml
+++ b/test/expected-tools-args-array-of-object-mcp.yaml
@@ -54,6 +54,9 @@ tools:
           properties:
             pages:
               description: 识别pages
+              items:
+                description: 单张识别
+                type: string
               type: array
           type: object
       type: object

--- a/test/output-schema-test.json
+++ b/test/output-schema-test.json
@@ -1,0 +1,119 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Output Schema Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users list",
+        "description": "Retrieve a list of users",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "description": "List of users",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "User ID"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "User name"
+                          },
+                          "email": {
+                            "type": "string",
+                            "description": "User email"
+                          }
+                        },
+                        "required": ["id", "name"]
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total number of users"
+                    }
+                  },
+                  "required": ["users", "total"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "summary": "Get user by ID",
+        "description": "Retrieve a single user by ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "User ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "User ID"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "User name"
+                    },
+                    "email": {
+                      "type": "string",
+                      "description": "User email"
+                    },
+                    "profile": {
+                      "type": "object",
+                      "description": "User profile information",
+                      "properties": {
+                        "bio": {
+                          "type": "string",
+                          "description": "User biography"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "User website"
+                        }
+                      }
+                    }
+                  },
+                  "required": ["id", "name", "email"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/template-with-output-schema.yaml
+++ b/test/template-with-output-schema.yaml
@@ -1,0 +1,21 @@
+server:
+  name: "openapi-server"
+  config:
+    baseUrl: "https://api.example.com"
+tools:
+  outputSchema:
+    type: object
+    description: "Default output schema for all tools"
+    properties:
+      success:
+        type: boolean
+        description: "Indicates if the operation was successful"
+      message:
+        type: string
+        description: "Response message"
+  requestTemplate:
+    headers:
+      - key: "Authorization"
+        value: "Bearer {{.config.apiKey}}"
+      - key: "X-API-Version"
+        value: "v1"


### PR DESCRIPTION
feat: add support for MCP Protocol 2025-06-18 with output schemas and structured content responses

- Introduced output schema generation for tools based on OpenAPI response definitions.
- Enhanced compatibility with MCP Protocol 2025-06-18, allowing structured content responses.
- Updated README to reflect new features and usage instructions.
- Added unit tests for output schema creation and validation.