### PR TITLE
Add subschemas

### DIFF
--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -96,6 +96,12 @@ func TestEndToEndConversion(t *testing.T) {
 			expectedOutput: "../../test/expected-output-schema-test-mcp.yaml",
 			serverName:     "output-schema-api",
 		},
+		{
+			name:           "Handle Subschemas",
+			inputFile:      "../../test/subschemas.json",
+			expectedOutput: "../../test/expected-subschemas-mcp.yaml",
+			serverName:     "openapi-server",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/expected-subschemas-mcp.yaml
+++ b/test/expected-subschemas-mcp.yaml
@@ -1,0 +1,25 @@
+server:
+  name: openapi-server
+tools:
+  - name: post_user
+    description: Test allOf, anyOf, and oneOf in request body
+    args:
+      - name: allOfUser
+        description: Combines both BaseUser and ExtraInfo via allOf
+        type: object
+        position: body
+      - name: anyOfUser
+        description: Valid if matches any of BaseUser or ExtraInfo
+        type: object
+        position: body
+      - name: oneOfUser
+        description: Valid if matches exactly one of BaseUser or ExtraInfo
+        type: object
+        position: body
+    requestTemplate:
+      url: /user
+      method: POST
+      headers:
+        - key: Content-Type
+          value: application/json
+    responseTemplate: {}

--- a/test/subschemas.json
+++ b/test/subschemas.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Composition Test API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/user": {
+      "post": {
+        "summary": "Test allOf, anyOf, and oneOf in request body",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompositionTest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CompositionTest": {
+        "type": "object",
+        "properties": {
+          "allOfUser": {
+            "description": "Combines both BaseUser and ExtraInfo via allOf",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseUser"
+              },
+              {
+                "$ref": "#/components/schemas/ExtraInfo"
+              }
+            ]
+          },
+          "anyOfUser": {
+            "description": "Valid if matches any of BaseUser or ExtraInfo",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseUser"
+              },
+              {
+                "$ref": "#/components/schemas/ExtraInfo"
+              }
+            ]
+          },
+          "oneOfUser": {
+            "description": "Valid if matches exactly one of BaseUser or ExtraInfo",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BaseUser"
+              },
+              {
+                "$ref": "#/components/schemas/ExtraInfo"
+              }
+            ]
+          }
+        }
+      },
+      "BaseUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "ExtraInfo": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "age": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add support for `anyOf`, `allOf`, `oneOf`, if all the subschemas within is the same type, it should follow that type.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🎨 Code refactoring
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling updates

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added necessary tests
- [x] All tests are passing
- [x] I have updated relevant documentation
- [x] My changes do not break existing functionality

## Testing

Please describe how you tested these changes:

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Related Issues

If applicable, link to related issues:

- Closes #
- Related #

## Additional Information

If there is any other information that should be included, please add it here.
