### PR TITLE
feat: preserve security scheme defaultCredential in conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,9 @@ server:
   # ... other server config ...
 ```
 
-The `defaultCredential` field within a security scheme is an MCP-specific extension and is not derived from the OpenAPI specification. You can set it using the `--template` feature if needed.
+The `defaultCredential` field within a security scheme is an MCP-specific extension (not part of the OpenAPI standard fields). During conversion, this tool reads `x-defaultCredential` (recommended) and also supports `defaultCredential` for backward compatibility.
+
+If you run with `--validate`, use `x-defaultCredential` because non-`x-` custom fields may be rejected by OpenAPI validation.
 
 ### Tool-Level Security Requirements
 

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -58,13 +58,12 @@ func (c *Converter) Convert() (*models.MCPConfig, error) {
 			if schemeRef != nil && schemeRef.Value != nil {
 				scheme := schemeRef.Value
 				mcpScheme := models.SecurityScheme{
-					ID:     name,
-					Type:   scheme.Type,
-					Scheme: scheme.Scheme,
-					In:     scheme.In,
-					Name:   scheme.Name,
-					// DefaultCredential is not directly available in OpenAPI SecurityScheme,
-					// it's an extension for MCP. User can set it via template or manually.
+					ID:                name,
+					Type:              scheme.Type,
+					Scheme:            scheme.Scheme,
+					In:                scheme.In,
+					Name:              scheme.Name,
+					DefaultCredential: extractDefaultCredential(scheme),
 				}
 				config.Server.SecuritySchemes = append(config.Server.SecuritySchemes, mcpScheme)
 			}
@@ -101,6 +100,34 @@ func (c *Converter) Convert() (*models.MCPConfig, error) {
 	})
 
 	return config, nil
+}
+
+// extractDefaultCredential gets MCP-specific default credential from security scheme extensions.
+// It prefers the OpenAPI extension key x-defaultCredential, and falls back to defaultCredential
+// for backward compatibility.
+func extractDefaultCredential(scheme *openapi3.SecurityScheme) string {
+	if scheme == nil || len(scheme.Extensions) == 0 {
+		return ""
+	}
+
+	if value, found := scheme.Extensions["x-defaultCredential"]; found {
+		return stringifyExtensionValue(value)
+	}
+	if value, found := scheme.Extensions["defaultCredential"]; found {
+		return stringifyExtensionValue(value)
+	}
+
+	return ""
+}
+
+func stringifyExtensionValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	if str, ok := value.(string); ok {
+		return str
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 // applyTemplate applies a template to the generated configuration

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -79,6 +79,12 @@ func TestEndToEndConversion(t *testing.T) {
 			serverName:     "openapi-server", // Matches the default or can be specified if different
 		},
 		{
+			name:           "Security Schemes With Default Credential",
+			inputFile:      "../../test/security-default-credential-test.json",
+			expectedOutput: "../../test/expected-security-default-credential-test-mcp.yaml",
+			serverName:     "openapi-server",
+		},
+		{
 			name:           "Tools Args array of object",
 			inputFile:      "../../test/tools-args-array-of-object.json",
 			expectedOutput: "../../test/expected-tools-args-array-of-object-mcp.yaml",
@@ -160,6 +166,60 @@ func TestEndToEndConversion(t *testing.T) {
 
 			// Compare the actual and expected output
 			assert.Equal(t, string(expectedYAML), string(actualYAML))
+		})
+	}
+}
+
+func TestExtractDefaultCredential(t *testing.T) {
+	testCases := []struct {
+		name       string
+		extensions map[string]any
+		expected   string
+	}{
+		{
+			name: "prefer x-defaultCredential when both exist",
+			extensions: map[string]any{
+				"x-defaultCredential": "from-extension",
+				"defaultCredential":   "from-legacy",
+			},
+			expected: "from-extension",
+		},
+		{
+			name: "fallback to legacy defaultCredential",
+			extensions: map[string]any{
+				"defaultCredential": "legacy-value",
+			},
+			expected: "legacy-value",
+		},
+		{
+			name: "stringify non-string extension value",
+			extensions: map[string]any{
+				"defaultCredential": 12345,
+			},
+			expected: "12345",
+		},
+		{
+			name: "return empty when extension missing",
+			extensions: map[string]any{
+				"x-another-field": "value",
+			},
+			expected: "",
+		},
+		{
+			name: "return empty for nil extension value",
+			extensions: map[string]any{
+				"defaultCredential": nil,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := &openapi3.SecurityScheme{
+				Extensions: tc.extensions,
+			}
+			assert.Equal(t, tc.expected, extractDefaultCredential(scheme))
 		})
 	}
 }

--- a/test/expected-security-default-credential-test-mcp.yaml
+++ b/test/expected-security-default-credential-test-mcp.yaml
@@ -1,0 +1,29 @@
+server:
+  name: openapi-server
+  securitySchemes:
+    - id: ApiKeyHeaderAuth
+      type: apiKey
+      in: header
+      name: X-API-KEY
+      defaultCredential: header-key
+    - id: ApiKeyQueryAuth
+      type: apiKey
+      in: query
+      name: api_key
+      defaultCredential: query-key
+    - id: BasicAuth
+      type: http
+      scheme: basic
+      defaultCredential: basic-user-pass
+    - id: BearerAuth
+      type: http
+      scheme: bearer
+      defaultCredential: bearer-token
+tools:
+  - name: getHello
+    description: Get hello
+    args: []
+    requestTemplate:
+      url: http://localhost:8080/hello
+      method: GET
+    responseTemplate: {}

--- a/test/security-default-credential-test.json
+++ b/test/security-default-credential-test.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Security Default Credential Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "defaultCredential": "basic-user-pass"
+      },
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "x-defaultCredential": "bearer-token"
+      },
+      "ApiKeyHeaderAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY",
+        "defaultCredential": "header-key"
+      },
+      "ApiKeyQueryAuth": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "x-defaultCredential": "query-key"
+      }
+    }
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "summary": "Get hello",
+        "operationId": "getHello",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Keep credentials defined in security scheme extensions during OpenAPI-to-MCP conversion, so downstream users can rely on direct spec fields without template-only overrides.

Made-with: Cursor

## Description

Please provide a brief description of your changes.

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🎨 Code refactoring
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling updates

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have added necessary tests
- [ ] All tests are passing
- [ ] I have updated relevant documentation
- [ ] My changes do not break existing functionality

## Testing

Please describe how you tested these changes:

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Related Issues

If applicable, link to related issues:

- Closes #
- Related #

## Additional Information

If there is any other information that should be included, please add it here.
