### PR TITLE
feat: support nullable and default values in OAS to MCP conversion

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -337,6 +337,11 @@ func (c *Converter) convertParameters(parameters openapi3.Parameters) ([]models.
 			// Set the type based on the schema type
 			arg.Type = schema.Type
 
+			// Handle default value
+			if schema.Default != nil {
+				arg.Default = schema.Default
+			}
+
 			// Handle enum values
 			if len(schema.Enum) > 0 {
 				arg.Enum = schema.Enum
@@ -410,6 +415,11 @@ func (c *Converter) convertRequestBody(requestBodyRef *openapi3.RequestBodyRef) 
 					Position:    "body",
 				}
 
+				// Handle default value
+				if schema.Default != nil {
+					arg.Default = schema.Default
+				}
+
 				// Set items schema
 				arg.Items = map[string]any{
 					"type": schema.Items.Value.Type,
@@ -443,6 +453,11 @@ func (c *Converter) convertRequestBody(requestBodyRef *openapi3.RequestBodyRef) 
 						Type:        propRef.Value.Type,
 						Required:    contains(schema.Required, propName),
 						Position:    "body", // Set position to "body" for request body parameters
+					}
+
+					// Handle default value
+					if propRef.Value.Default != nil {
+						arg.Default = propRef.Value.Default
 					}
 
 					// Handle enum values
@@ -875,6 +890,11 @@ func (c *Converter) convertPropertiesWithVisited(properties map[string]*openapi3
 			propSchema["description"] = propRef.Value.Description
 		}
 
+		// Handle nullable - use JSON Schema type array format ["type", "null"]
+		if propRef.Value.Nullable {
+			propSchema["type"] = []any{propRef.Value.Type, "null"}
+		}
+
 		// Handle nested object properties recursively
 		if propRef.Value.Type == "object" && len(propRef.Value.Properties) > 0 {
 			// Mark this schema as visited
@@ -959,7 +979,7 @@ func (c *Converter) convertNestedPropertiesWithVisited(schema *openapi3.Schema, 
 
 			propSchema := make(map[string]any)
 
-			// Add fields in alphabetical order for deterministic output: default, description, enum, type
+			// Add fields in alphabetical order for deterministic output: default, description, enum, nullable, type
 			if propRef.Value.Default != nil {
 				propSchema["default"] = propRef.Value.Default
 			}

--- a/test/expected-header-params-mcp.yaml
+++ b/test/expected-header-params-mcp.yaml
@@ -50,6 +50,7 @@ tools:
       - name: Accept-Language
         description: Preferred language for response
         type: string
+        default: en-US
         position: header
       - name: Authorization
         description: Bearer token for authentication

--- a/test/expected-tools-args-array-of-object-mcp.yaml
+++ b/test/expected-tools-args-array-of-object-mcp.yaml
@@ -8,6 +8,7 @@ tools:
         description: 图片list base64
         type: array
         required: true
+        default: []
         items:
           description: image
           properties:


### PR DESCRIPTION
## Summary

Support OpenAPI `default` field during OAS → MCP config conversion, and remove `nullable` from args output (Higress does not consume it).

## Changes

**default support:**
- Parameters (query/path/header/cookie): extract `default` from OAS schema into MCP arg
- Request body properties: same
- Array-type body args: same

**nullable handling:**
- `args`: removed `Nullable` field from `Arg` struct — Higress does not use it, and its semantics overlap with `required`
- `outputSchema`: OAS `nullable: true` → `type: ["originalType", "null"]` (standard JSON Schema, directly consumed by MCP clients)

**multipart binary check removed:**
- The old hardcoded `multipart/form-data` binary error in `convertRequestBody` is removed — this responsibility moves to the standalone MCP compatibility validator (see PR #35)

## Test updates

- `expected-header-params-mcp.yaml` — `Accept-Language` now has `default: en-US`
- `expected-tools-args-array-of-object-mcp.yaml` — `pages` now has `default: []`
- `expected-request-body-types-mcp.yaml` — regenerated (multipart operation now produces empty args instead of erroring)