### PR TITLE
feat: add MCP compatibility validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ openapi-to-mcp --input path/to/openapi.json --output path/to/mcp-server.yaml
 - `--tool-prefix`: Prefix for tool names (default: "")
 - `--format`: Output format (yaml or json) (default: "yaml")
 - `--validate`: Validate the OpenAPI specification (default: false)
+- `--mcp-compat`: MCP compatibility check mode: `strict` or `warn` (default: disabled)
 - `--template`: Path to a template file to patch the output (default: "")
 
 ## Example
@@ -510,6 +511,24 @@ When using the generated configuration with Higress:
 4. No additional configuration is required - the presence of output schemas enables the new features
 
 For more information about MCP Protocol 2025-06-18, refer to the [MCP specification](https://modelcontextprotocol.io/specification).
+
+## MCP Compatibility Check
+
+Not all OpenAPI operations can be converted to MCP tools. MCP only accepts JSON-serializable inputs, so operations using binary uploads, streaming, or non-JSON content types are incompatible.
+
+Use `--mcp-compat` to detect these issues:
+
+```bash
+# Strict mode: error and stop on incompatible operations
+openapi-to-mcp --input api.json --output mcp.yaml --mcp-compat strict
+
+# Warn mode: skip incompatible operations with warnings, convert the rest
+openapi-to-mcp --input api.json --output mcp.yaml --mcp-compat warn
+```
+
+When not specified, no compatibility check is performed (backward compatible).
+
+For details on detected patterns and how to fix them, see [MCP Compatibility Guide](docs/mcp-compatibility.md).
 
 ## Contributing
 

--- a/cmd/openapi-to-mcp/main.go
+++ b/cmd/openapi-to-mcp/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/higress-group/openapi-to-mcpserver/pkg/converter"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/models"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/parser"
+	"github.com/higress-group/openapi-to-mcpserver/pkg/validator"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,6 +23,7 @@ func main() {
 	toolNamePrefix := flag.String("tool-prefix", "", "Prefix for tool names")
 	format := flag.String("format", "yaml", "Output format (yaml or json)")
 	validate := flag.Bool("validate", false, "Validate the OpenAPI specification")
+	mcpCompat := flag.String("mcp-compat", "", "MCP compatibility check mode: 'strict' (error on incompatible operations) or 'warn' (skip with warnings)")
 	templateFile := flag.String("template", "", "Path to a template file to patch the output")
 
 	// Parse command-line flags
@@ -40,6 +42,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Validate MCP compatibility mode flag
+	compatMode, valid := validator.ParseMCPCompatMode(*mcpCompat)
+	if !valid {
+		fmt.Printf("Error: invalid mcp-compat mode %q (must be 'strict' or 'warn')\n", *mcpCompat)
+		os.Exit(1)
+	}
+
 	// Create a new parser
 	p := parser.NewParser()
 
@@ -53,12 +62,40 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Run MCP compatibility validation if enabled
+	var compatResult *validator.MCPCompatResult
+	if compatMode != validator.MCPCompatOff {
+		compatResult = validator.ValidateDocument(p.GetDocument())
+
+		if len(compatResult.Issues) > 0 {
+			if compatMode == validator.MCPCompatStrict {
+				fmt.Println("Error: OpenAPI specification contains MCP-incompatible operations:")
+				for _, issue := range compatResult.Issues {
+					fmt.Printf("  %s\n", issue.String())
+				}
+				os.Exit(1)
+			}
+			// Warn mode: print warnings, will skip these operations during conversion
+			for _, issue := range compatResult.Issues {
+				fmt.Printf("Warning: %s\n", issue.String())
+			}
+			fmt.Println()
+		}
+	}
+
 	// Create a new converter
 	c := converter.NewConverter(p, models.ConvertOptions{
 		ServerName:     *serverName,
 		ToolNamePrefix: *toolNamePrefix,
 		TemplatePath:   *templateFile,
 	})
+
+	// Set skip filter if in warn mode with incompatible operations
+	if compatResult != nil && compatMode == validator.MCPCompatWarn {
+		c.SkipFilter = func(path, method string) bool {
+			return !compatResult.IsCompatible(path, method)
+		}
+	}
 
 	// Convert the OpenAPI specification to an MCP configuration
 	config, err := c.Convert()

--- a/docs/mcp-compatibility.md
+++ b/docs/mcp-compatibility.md
@@ -1,0 +1,66 @@
+# MCP Compatibility Guide
+
+MCP (Model Context Protocol) tools communicate via JSON-RPC. All tool inputs must be JSON-serializable, and tool calls follow a synchronous request-response model. This means certain OpenAPI operations cannot be directly converted to MCP tools.
+
+The `--mcp-compat` flag detects these incompatibilities before conversion.
+
+## Detected Patterns
+
+| Incompatible Pattern | Reason |
+|---|---|
+| `application/octet-stream` request body | Binary stream cannot be JSON-serialized |
+| `multipart/form-data` request body | Multipart encoding has no JSON equivalent |
+| `text/event-stream` request body | Streaming input not supported |
+| `application/xml` / `text/xml` request body | XML cannot be passed as JSON tool arguments |
+| `image/*`, `audio/*`, `video/*` request body | Media types cannot be JSON-serialized as input |
+| `format: "binary"` fields in request body | Binary data cannot be transmitted as MCP tool input |
+| `text/event-stream` in response | MCP tool calls are synchronous; streaming responses are incompatible |
+
+> **Note**: MCP tool *results* (outputs) support image and audio via base64 encoding. The check only flags issues on the **input** side, except for streaming responses which fundamentally conflict with MCP's synchronous model.
+
+## Modes
+
+### Strict Mode (`--mcp-compat strict`)
+
+Prints all incompatible operations and exits with a non-zero status code. No output file is generated.
+
+```
+$ openapi-to-mcp --input api.json --output mcp.yaml --mcp-compat strict
+
+Error: OpenAPI specification contains MCP-incompatible operations:
+  [MCP incompatible] uploadFile: request body content type "application/octet-stream" is not supported by MCP (only JSON-serializable inputs are allowed)
+  [MCP incompatible] streamEvents: response (200) uses streaming content type "text/event-stream", MCP tool calls are synchronous request-response
+  [MCP incompatible] uploadAvatar: request body content type "multipart/form-data" is not supported by MCP (multipart form data cannot be represented as JSON tool arguments)
+```
+
+**When to use**: CI pipelines, pre-commit checks, or when you want to ensure the entire spec is MCP-compatible.
+
+### Warn Mode (`--mcp-compat warn`)
+
+Prints warnings for incompatible operations, skips them, and converts the remaining compatible operations.
+
+```
+$ openapi-to-mcp --input api.json --output mcp.yaml --mcp-compat warn
+
+Warning: [MCP incompatible] uploadFile: request body content type "application/octet-stream" is not supported by MCP (only JSON-serializable inputs are allowed)
+Warning: [MCP incompatible] streamEvents: response (200) uses streaming content type "text/event-stream", MCP tool calls are synchronous request-response
+Warning: [MCP incompatible] uploadAvatar: request body content type "multipart/form-data" is not supported by MCP (multipart form data cannot be represented as JSON tool arguments)
+
+Successfully converted OpenAPI specification to MCP configuration: mcp.yaml
+```
+
+The output file will only contain tools from compatible operations.
+
+**When to use**: When your API has a mix of compatible and incompatible endpoints, and you want to convert what's possible.
+
+## How to Fix Incompatible Operations
+
+If you need the flagged operations available as MCP tools:
+
+1. **File uploads** (`multipart/form-data`, `application/octet-stream`): Redesign the API to accept a URL or base64-encoded string in a JSON body instead of raw binary.
+2. **Streaming responses** (`text/event-stream`): Provide an alternative polling endpoint that returns the current state as a JSON object.
+3. **XML request bodies**: Add an `application/json` content type alternative to the operation.
+
+## Default Behavior
+
+When `--mcp-compat` is not specified, no compatibility check is performed and all operations are converted regardless of compatibility. This preserves backward compatibility with existing workflows.

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -18,6 +18,9 @@ import (
 type Converter struct {
 	parser  *parser.Parser
 	options models.ConvertOptions
+	// SkipFilter optionally filters out operations that should not be converted.
+	// If set, returns true for path+method combinations that should be skipped.
+	SkipFilter func(path, method string) bool
 }
 
 // NewConverter creates a new OpenAPI to MCP converter
@@ -78,6 +81,11 @@ func (c *Converter) Convert() (*models.MCPConfig, error) {
 	for path, pathItem := range c.parser.GetPaths() {
 		operations := getOperations(pathItem)
 		for method, operation := range operations {
+			// Skip if filtered out
+			if c.SkipFilter != nil && c.SkipFilter(path, method) {
+				continue
+			}
+
 			tool, err := c.convertOperation(path, method, operation)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert operation %s %s: %w", method, path, err)

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -10,9 +11,18 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/models"
 	"github.com/higress-group/openapi-to-mcpserver/pkg/parser"
+	"github.com/higress-group/openapi-to-mcpserver/pkg/validator"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
+
+func mustMarshalJSON(v any) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
 
 func TestEndToEndConversion(t *testing.T) {
 	// Test cases
@@ -451,4 +461,71 @@ func TestCreateOutputSchemaArrayRoot(t *testing.T) {
 	assert.True(t, ok)
 	assert.Contains(t, properties, "id")
 	assert.Contains(t, properties, "name")
+}
+
+func TestConvertRequestBodyMultipartBinaryError(t *testing.T) {
+	binarySchema := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: "string", Format: "binary"}}
+	arrayBinarySchema := &openapi3.SchemaRef{Value: &openapi3.Schema{
+		Type:  "array",
+		Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: "string", Format: "binary"}},
+	}}
+	textSchema := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: "string"}}
+
+	tests := []struct {
+		name           string
+		props          map[string]*openapi3.SchemaRef
+		expectIncompat bool
+	}{
+		{"direct binary field", map[string]*openapi3.SchemaRef{"file": binarySchema, "name": textSchema}, true},
+		{"array of binary files", map[string]*openapi3.SchemaRef{"files": arrayBinarySchema, "id": textSchema}, true},
+		{"no binary fields", map[string]*openapi3.SchemaRef{"name": textSchema}, true}, // multipart itself is incompatible
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parser.NewParser()
+			doc := &openapi3.T{
+				OpenAPI: "3.0.0",
+				Info:    &openapi3.Info{Title: "test", Version: "1.0"},
+				Paths: map[string]*openapi3.PathItem{
+					"/upload": {
+						Post: &openapi3.Operation{
+							OperationID: "uploadFile",
+							RequestBody: &openapi3.RequestBodyRef{Value: &openapi3.RequestBody{
+								Content: map[string]*openapi3.MediaType{
+									"multipart/form-data": {
+										Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+											Type:       "object",
+											Properties: tc.props,
+										}},
+									},
+								},
+							}},
+							Responses: openapi3.Responses{},
+						},
+					},
+				},
+			}
+			err := p.Parse(mustMarshalJSON(doc))
+			assert.NoError(t, err)
+
+			// Use validator directly (decoupled from converter)
+			result := validator.ValidateDocument(p.GetDocument())
+			if tc.expectIncompat {
+				assert.NotEmpty(t, result.Issues)
+				assert.False(t, result.IsCompatible("/upload", "post"))
+				// Verify the issue message mentions "not supported" or "multipart"
+				found := false
+				for _, issue := range result.Issues {
+					if strings.Contains(issue.Reason, "not supported") || strings.Contains(issue.Reason, "multipart") {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected issue about multipart/binary not supported")
+			} else {
+				assert.True(t, result.IsCompatible("/upload", "post"))
+			}
+		})
+	}
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,0 +1,273 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// MCPCompatMode defines how to handle incompatible operations
+type MCPCompatMode int
+
+const (
+	// MCPCompatOff disables MCP compatibility checking
+	MCPCompatOff MCPCompatMode = iota
+	// MCPCompatStrict reports errors and stops on incompatible operations
+	MCPCompatStrict
+	// MCPCompatWarn skips incompatible operations with warnings
+	MCPCompatWarn
+)
+
+// ParseMCPCompatMode parses a string into MCPCompatMode
+func ParseMCPCompatMode(s string) (MCPCompatMode, bool) {
+	switch s {
+	case "strict":
+		return MCPCompatStrict, true
+	case "warn":
+		return MCPCompatWarn, true
+	case "":
+		return MCPCompatOff, true
+	default:
+		return MCPCompatOff, false
+	}
+}
+
+// MCPCompatIssue represents a single compatibility issue found during validation
+type MCPCompatIssue struct {
+	Path        string // API path, e.g., "/pets/{id}/upload"
+	Method      string // HTTP method, e.g., "POST"
+	OperationID string // Operation ID if available
+	Reason      string // Human-readable description of the issue
+}
+
+func (i MCPCompatIssue) String() string {
+	op := i.OperationID
+	if op == "" {
+		op = fmt.Sprintf("%s %s", strings.ToUpper(i.Method), i.Path)
+	}
+	return fmt.Sprintf("[MCP incompatible] %s: %s", op, i.Reason)
+}
+
+// MCPCompatResult holds the validation result for the entire document
+type MCPCompatResult struct {
+	Issues            []MCPCompatIssue
+	IncompatiblePaths map[string]map[string]bool // path -> method -> true
+}
+
+// IsCompatible returns true if a specific path+method combination is compatible
+func (r *MCPCompatResult) IsCompatible(path, method string) bool {
+	if r == nil || r.IncompatiblePaths == nil {
+		return true
+	}
+	methods, exists := r.IncompatiblePaths[path]
+	if !exists {
+		return true
+	}
+	return !methods[strings.ToLower(method)]
+}
+
+// unsupportedContentTypes lists content types that cannot be represented as JSON input in MCP
+var unsupportedContentTypes = []string{
+	"application/octet-stream",
+	"text/event-stream",
+	"application/xml",
+	"text/xml",
+	"image/",
+	"audio/",
+	"video/",
+}
+
+// ValidateDocument checks all operations in an OpenAPI document for MCP compatibility.
+// Returns the validation result containing all issues found.
+func ValidateDocument(doc *openapi3.T) *MCPCompatResult {
+	result := &MCPCompatResult{
+		Issues:            []MCPCompatIssue{},
+		IncompatiblePaths: make(map[string]map[string]bool),
+	}
+
+	if doc == nil || doc.Paths == nil {
+		return result
+	}
+
+	for path, pathItem := range doc.Paths {
+		operations := getOperations(pathItem)
+		for method, operation := range operations {
+			issues := checkOperation(path, method, operation)
+			if len(issues) > 0 {
+				result.Issues = append(result.Issues, issues...)
+				if result.IncompatiblePaths[path] == nil {
+					result.IncompatiblePaths[path] = make(map[string]bool)
+				}
+				result.IncompatiblePaths[path][method] = true
+			}
+		}
+	}
+
+	return result
+}
+
+// getOperations returns a map of HTTP method to operation
+func getOperations(pathItem *openapi3.PathItem) map[string]*openapi3.Operation {
+	operations := make(map[string]*openapi3.Operation)
+	if pathItem.Get != nil {
+		operations["get"] = pathItem.Get
+	}
+	if pathItem.Post != nil {
+		operations["post"] = pathItem.Post
+	}
+	if pathItem.Put != nil {
+		operations["put"] = pathItem.Put
+	}
+	if pathItem.Delete != nil {
+		operations["delete"] = pathItem.Delete
+	}
+	if pathItem.Options != nil {
+		operations["options"] = pathItem.Options
+	}
+	if pathItem.Head != nil {
+		operations["head"] = pathItem.Head
+	}
+	if pathItem.Patch != nil {
+		operations["patch"] = pathItem.Patch
+	}
+	if pathItem.Trace != nil {
+		operations["trace"] = pathItem.Trace
+	}
+	return operations
+}
+
+// checkOperation performs all compatibility checks on a single operation
+func checkOperation(path, method string, operation *openapi3.Operation) []MCPCompatIssue {
+	var issues []MCPCompatIssue
+
+	operationID := ""
+	if operation.OperationID != "" {
+		operationID = operation.OperationID
+	}
+
+	// Check request body content types and schemas
+	if operation.RequestBody != nil && operation.RequestBody.Value != nil {
+		requestBody := operation.RequestBody.Value
+		for contentType, mediaType := range requestBody.Content {
+			// Check for unsupported content types
+			if issue := checkContentType(path, method, operationID, contentType); issue != nil {
+				issues = append(issues, *issue)
+				continue
+			}
+
+			// Check for binary/stream formats in schema
+			if mediaType.Schema != nil && mediaType.Schema.Value != nil {
+				schemaIssues := checkSchemaForBinary(path, method, operationID, contentType, mediaType.Schema.Value)
+				issues = append(issues, schemaIssues...)
+			}
+		}
+	}
+
+	// Check response for streaming (text/event-stream)
+	if operation.Responses != nil {
+		for code, responseRef := range operation.Responses {
+			if responseRef == nil || responseRef.Value == nil {
+				continue
+			}
+			for contentType := range responseRef.Value.Content {
+				if strings.Contains(contentType, "text/event-stream") {
+					issues = append(issues, MCPCompatIssue{
+						Path:        path,
+						Method:      method,
+						OperationID: operationID,
+						Reason:      fmt.Sprintf("response (%s) uses streaming content type %q, MCP tool calls are synchronous request-response", code, contentType),
+					})
+				}
+			}
+		}
+	}
+
+	return issues
+}
+
+// checkContentType checks if a request body content type is supported by MCP
+func checkContentType(path, method, operationID, contentType string) *MCPCompatIssue {
+	ct := strings.ToLower(contentType)
+
+	for _, unsupported := range unsupportedContentTypes {
+		if strings.Contains(ct, unsupported) {
+			return &MCPCompatIssue{
+				Path:        path,
+				Method:      method,
+				OperationID: operationID,
+				Reason:      fmt.Sprintf("request body content type %q is not supported by MCP (only JSON-serializable inputs are allowed)", contentType),
+			}
+		}
+	}
+
+	// multipart/form-data is generally problematic for MCP
+	if strings.Contains(ct, "multipart/form-data") {
+		return &MCPCompatIssue{
+			Path:        path,
+			Method:      method,
+			OperationID: operationID,
+			Reason:      fmt.Sprintf("request body content type %q is not supported by MCP (multipart form data cannot be represented as JSON tool arguments)", contentType),
+		}
+	}
+
+	return nil
+}
+
+// checkSchemaForBinary checks a schema for binary/stream format fields
+func checkSchemaForBinary(path, method, operationID, contentType string, schema *openapi3.Schema) []MCPCompatIssue {
+	var issues []MCPCompatIssue
+
+	// Check top-level schema format
+	if schema.Format == "binary" {
+		issues = append(issues, MCPCompatIssue{
+			Path:        path,
+			Method:      method,
+			OperationID: operationID,
+			Reason:      fmt.Sprintf("request body (%s) uses format \"binary\" which cannot be transmitted as MCP tool input", contentType),
+		})
+		return issues
+	}
+
+	// Check object properties for binary fields
+	if schema.Type == "object" {
+		for propName, propRef := range schema.Properties {
+			if propRef.Value == nil {
+				continue
+			}
+			if propRef.Value.Format == "binary" {
+				issues = append(issues, MCPCompatIssue{
+					Path:        path,
+					Method:      method,
+					OperationID: operationID,
+					Reason:      fmt.Sprintf("request body field %q uses format \"binary\" which cannot be transmitted as MCP tool input", propName),
+				})
+			}
+			// Check array items with binary format
+			if propRef.Value.Type == "array" && propRef.Value.Items != nil && propRef.Value.Items.Value != nil {
+				if propRef.Value.Items.Value.Format == "binary" {
+					issues = append(issues, MCPCompatIssue{
+						Path:        path,
+						Method:      method,
+						OperationID: operationID,
+						Reason:      fmt.Sprintf("request body field %q is an array of binary items which cannot be transmitted as MCP tool input", propName),
+					})
+				}
+			}
+		}
+	}
+
+	// Check array items
+	if schema.Type == "array" && schema.Items != nil && schema.Items.Value != nil {
+		if schema.Items.Value.Format == "binary" {
+			issues = append(issues, MCPCompatIssue{
+				Path:        path,
+				Method:      method,
+				OperationID: operationID,
+				Reason:      fmt.Sprintf("request body (%s) is an array of binary items which cannot be transmitted as MCP tool input", contentType),
+			})
+		}
+	}
+
+	return issues
+}


### PR DESCRIPTION
## Summary

Add `--mcp-compat` flag to validate OpenAPI operations against MCP protocol constraints before conversion.

## Changes

- New `pkg/validator` package: standalone MCP compatibility checker
- New `--mcp-compat` CLI flag with two modes:
  - `strict`: error and exit on incompatible operations
  - `warn`: skip incompatible operations with warnings, convert the rest
- Converter gains `SkipFilter` field for external filtering of operations
- Documentation: `docs/mcp-compatibility.md` with detected patterns and fix suggestions

## What Gets Detected

- Binary content types (`application/octet-stream`, `multipart/form-data`)
- Streaming (`text/event-stream` in request or response)
- Non-JSON content types (XML, image/*, audio/*, video/*)
- `format: binary` fields in request body schemas

## Backward Compatibility

Default behavior (no flag) is unchanged — all operations are converted without checking.