### PR TITLE
fix: inherit global security when operation-level security is not set

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -535,9 +535,16 @@ func (c *Converter) createRequestTemplate(path, method string, operation *openap
 	}
 
 	// Process operation-level security requirements
+	// If operation-level security is not set, fall back to global security
 	securitySchemeFound := false
-	if operation.Security != nil {
-		for _, securityRequirement := range *operation.Security {
+	securityRequirements := operation.Security
+	if securityRequirements == nil {
+		if doc := c.parser.GetDocument(); doc != nil && len(doc.Security) > 0 {
+			securityRequirements = &doc.Security
+		}
+	}
+	if securityRequirements != nil {
+		for _, securityRequirement := range *securityRequirements {
 			if securitySchemeFound {
 				break
 			}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -91,6 +91,12 @@ func TestEndToEndConversion(t *testing.T) {
 			serverName:     "openapi-server",
 		},
 		{
+			name:           "Global Security Schemes API",
+			inputFile:      "../../test/global-security-test.json",
+			expectedOutput: "../../test/expected-global-security-test-mcp.yaml",
+			serverName:     "openapi-server",
+		},
+		{
 			name:           "Handle AllOf Parameters",
 			inputFile:      "../../test/allof-params.json",
 			expectedOutput: "../../test/expected-allof-params-mcp.yaml",

--- a/test/expected-global-security-test-mcp.yaml
+++ b/test/expected-global-security-test-mcp.yaml
@@ -1,0 +1,36 @@
+server:
+  name: openapi-server
+  securitySchemes:
+    - id: ApiKeyHeaderAuth
+      type: apiKey
+      in: header
+      name: X-API-KEY
+    - id: BearerAuth
+      type: http
+      scheme: bearer
+tools:
+  - name: getGlobalAuthResource
+    description: Resource using global security
+    args: []
+    requestTemplate:
+      url: http://localhost:8080/v1/global_auth_resource
+      method: GET
+      security:
+        id: BearerAuth
+    responseTemplate: {}
+  - name: getNoAuthResource
+    description: Resource explicitly disabling auth
+    args: []
+    requestTemplate:
+      url: http://localhost:8080/v1/no_auth_resource
+      method: GET
+    responseTemplate: {}
+  - name: getOverrideAuthResource
+    description: Resource overriding global security with ApiKey
+    args: []
+    requestTemplate:
+      url: http://localhost:8080/v1/override_auth_resource
+      method: GET
+      security:
+        id: ApiKeyHeaderAuth
+    responseTemplate: {}

--- a/test/expected-ref-test.yaml
+++ b/test/expected-ref-test.yaml
@@ -34,6 +34,8 @@ tools:
       headers:
         - key: Content-Type
           value: application/json
+      security:
+        id: ApiKeyAuth
     responseTemplate:
       prependBody: |+
         # API Response Information

--- a/test/global-security-test.json
+++ b/test/global-security-test.json
@@ -1,0 +1,75 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Global Security Test API",
+    "description": "API for testing global security scheme conversion"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080/v1"
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "HTTP Bearer Authentication"
+      },
+      "ApiKeyHeaderAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY",
+        "description": "API Key in Header"
+      }
+    }
+  },
+  "paths": {
+    "/global_auth_resource": {
+      "get": {
+        "summary": "Resource using global security",
+        "operationId": "getGlobalAuthResource",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/override_auth_resource": {
+      "get": {
+        "summary": "Resource overriding global security with ApiKey",
+        "operationId": "getOverrideAuthResource",
+        "security": [
+          {
+            "ApiKeyHeaderAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/no_auth_resource": {
+      "get": {
+        "summary": "Resource explicitly disabling auth",
+        "operationId": "getNoAuthResource",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

When OpenAPI security is defined at the root level (openapi3.T.Security)
instead of under each operation, the converter previously lost the security
configuration because it only checked operation.Security.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🎨 Code refactoring
- [x] 🧪 Test updates
- [ ] 🔧 Build/tooling updates

## Checklist

- [ ] My code follows the project's coding standards
- [x] I have added necessary tests
- [x] All tests are passing
- [ ] I have updated relevant documentation
- [x] My changes do not break existing functionality

## Testing

Please describe how you tested these changes:

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Related Issues

If applicable, link to related issues:

- Closes #
- Related #

## Additional Information

If there is any other information that should be included, please add it here.
