### PR TITLE
test: add Xquik read API fixture

### DIFF
--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -120,6 +120,12 @@ func TestEndToEndConversion(t *testing.T) {
 			expectedOutput: "../../test/expected-array-request-body-mcp.yaml",
 			serverName:     "array-body-api",
 		},
+		{
+			name:           "Xquik Read API",
+			inputFile:      "../../test/xquik-read-api.json",
+			expectedOutput: "../../test/expected-xquik-read-api-mcp.yaml",
+			serverName:     "xquik",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/expected-xquik-read-api-mcp.yaml
+++ b/test/expected-xquik-read-api-mcp.yaml
@@ -1,0 +1,89 @@
+server:
+  name: xquik
+  securitySchemes:
+    - id: apiKey
+      type: apiKey
+      in: header
+      name: x-api-key
+    - id: oauthBearer
+      type: http
+      scheme: bearer
+tools:
+  - name: searchTweets
+    description: Search tweets by query
+    args:
+      - name: limit
+        description: Maximum tweets to return.
+        type: integer
+        position: query
+      - name: q
+        description: Search query.
+        type: string
+        required: true
+        position: query
+      - name: queryType
+        description: Sort order.
+        type: string
+        enum:
+          - Latest
+          - Top
+        position: query
+    requestTemplate:
+      url: https://xquik.com/api/v1/x/tweets/search
+      method: GET
+      security:
+        id: apiKey
+    responseTemplate:
+      prependBody: |+
+        # API Response Information
+
+        Below is the response from an API call. To help you understand the data, I've provided:
+
+        1. A detailed description of all fields in the response structure
+        2. The complete API response
+
+        ## Response Structure
+
+        > Content-Type: application/json
+
+        - **has_next_page**: Whether another page is available. (Type: boolean)
+        - **next_cursor**: Cursor for the next page. (Type: string)
+        - **tweets**: Tweet results. (Type: array)
+          - **tweets[].author**: Tweet author. (Type: object)
+            - **tweets[].author.username**: Author username. (Type: string)
+          - **tweets[].id**: Tweet ID. (Type: string)
+          - **tweets[].text**: Tweet text. (Type: string)
+
+        ## Original Response
+
+    outputSchema:
+      description: Search results
+      properties:
+        has_next_page:
+          description: Whether another page is available.
+          type: boolean
+        next_cursor:
+          description: Cursor for the next page.
+          type: string
+        tweets:
+          description: Tweet results.
+          items:
+            properties:
+              author:
+                description: Tweet author.
+                properties:
+                  username:
+                    description: Author username.
+                    type: string
+                type: object
+              id:
+                description: Tweet ID.
+                type: string
+              text:
+                description: Tweet text.
+                type: string
+            type: object
+          type: array
+      required:
+        - tweets
+      type: object

--- a/test/xquik-read-api.json
+++ b/test/xquik-read-api.json
@@ -1,0 +1,130 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Xquik Read API",
+    "version": "1.0.0",
+    "description": "Compact fixture for an X data read endpoint with API key or OAuth bearer authentication."
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API key passed through the x-api-key header."
+      },
+      "oauthBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "OAuth 2.1 bearer token."
+      }
+    }
+  },
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "summary": "Search tweets by query",
+        "operationId": "searchTweets",
+        "security": [
+          {
+            "apiKey": []
+          },
+          {
+            "oauthBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search query."
+          },
+          {
+            "name": "queryType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Latest",
+                "Top"
+              ],
+              "default": "Latest"
+            },
+            "description": "Sort order."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 200
+            },
+            "description": "Maximum tweets to return."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "tweets"
+                  ],
+                  "properties": {
+                    "tweets": {
+                      "type": "array",
+                      "description": "Tweet results.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Tweet ID."
+                          },
+                          "text": {
+                            "type": "string",
+                            "description": "Tweet text."
+                          },
+                          "author": {
+                            "type": "object",
+                            "description": "Tweet author.",
+                            "properties": {
+                              "username": {
+                                "type": "string",
+                                "description": "Author username."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "has_next_page": {
+                      "type": "boolean",
+                      "description": "Whether another page is available."
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "description": "Cursor for the next page."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a compact Xquik read API fixture to the end-to-end OpenAPI conversion table. The fixture covers an API key security scheme, an OAuth bearer security scheme, query parameters, enum values, and nested response output schema generation.

Source check: https://xquik.com/openapi.json

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test updates
- [ ] Build/tooling updates

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added necessary tests
- [x] All tests are passing
- [ ] I have updated relevant documentation
- [x] My changes do not break existing functionality

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Commands run:

```bash
go test ./pkg/converter -run 'TestEndToEndConversion/Xquik_Read_API' -count=1 -v
go build ./...
go vet ./...
go test ./... -count=1 -v -race
go test ./... -coverprofile=coverage.out -covermode=atomic
```

## Related Issues

None.

## Additional Information

No credentials or runtime secrets are included.
